### PR TITLE
Handling the case for running and building ctags without jansson library

### DIFF
--- a/Tmain/json-output-format.d/input.c
+++ b/Tmain/json-output-format.d/input.c
@@ -1,0 +1,5 @@
+int
+main(void)
+{
+  return 0;
+}

--- a/Tmain/json-output-format.d/run.sh
+++ b/Tmain/json-output-format.d/run.sh
@@ -1,0 +1,10 @@
+# Copyright: 2016 Aman Gupta
+# License: GPL-2
+
+CTAGS=$1
+
+. ../utils.sh
+
+if is_feature_available ${CTAGS} json; then
+    run_with_format json
+fi

--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -1,0 +1,2 @@
+# json
+{"_type": "tag", "kind": "f", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "typeref": "int"}

--- a/Tmain/output-format-option.d/run.sh
+++ b/Tmain/output-format-option.d/run.sh
@@ -3,14 +3,8 @@
 
 CTAGS=$1
 
-run_with_format()
-{
-    echo '#' $1
-    ${CTAGS} --quiet --options=NONE --output-format=$1 -o - input.c
-}
-
+. ../utils.sh
 
 run_with_format ctags
 run_with_format etags
 run_with_format xref
-run_with_format json

--- a/Tmain/output-format-option.d/stdout-expected.txt
+++ b/Tmain/output-format-option.d/stdout-expected.txt
@@ -6,5 +6,3 @@ input.c,20
 main(void)main2,4
 # xref
 main             function      2 input.c          main(void)
-# json
-{"_type": "tag", "kind": "f", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "typeref": "int"}

--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -21,3 +21,9 @@ exit_if_no_coproc()
 {
     is_feature_available $1 coproc
 }
+
+run_with_format()
+{
+    echo '#' $1
+    ${CTAGS} --quiet --options=NONE --output-format=$1 -o - input.c
+}

--- a/main/options.c
+++ b/main/options.c
@@ -346,7 +346,11 @@ static optionDescription LongOptionDescription [] = {
  {1,"      The encoding to write the tag file in. Defaults to UTF-8 if --input-encoding"},
  {1,"      is specified, otherwise no conversion is performed."},
 #endif
- {0,"  --output-format=ctags|etags|xref|json"},
+ {0,"  --output-format=ctags|etags|xref"
+#ifdef HAVE_JANSSON
+  "|json"
+#endif
+ },
  {0,"      Specify the output format. [ctags]"},
  {0,"  --print-language"},
  {0,"       Don't make tags file but just print the guessed language name for"},
@@ -728,10 +732,12 @@ static void setXrefMode (void)
 	setTagWriter (writeXrefEntry, NULL, NULL);
 }
 
+#ifdef HAVE_JANSSON
 static void setJsonMode (void)
 {
 	setTagWriter (writeJsonEntry, NULL, NULL);
 }
+#endif
 
 /*
  *  Cooked argument parsing
@@ -2006,8 +2012,10 @@ static void processOutputFormat (const char *const option __unused__,
 		setEtagsMode ();
 	else if (strcmp (parameter, "xref") == 0)
 		setXrefMode ();
+#ifdef HAVE_JANSSON
 	else if (strcmp (parameter, "json") == 0)
 		setJsonMode ();
+#endif
 	else
 		error (FATAL, "unknown output format name supplied for \"%s=%s\"", option, parameter);
 }

--- a/main/output-json.c
+++ b/main/output-json.c
@@ -14,7 +14,10 @@
 #include "options.h"
 #include "output.h"
 #include "read.h"
+
+#ifdef HAVE_JANSSON
 #include <jansson.h>
+
 
 #define includeExtensionFlags()         (Option.tagFileFormat > 1)
 
@@ -134,3 +137,10 @@ extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data 
 
 	return length;
 }
+
+#else /* HAVE_JANSSON */
+extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)
+{
+	return 0;
+}
+#endif

--- a/source.mak
+++ b/source.mak
@@ -64,6 +64,7 @@ MAIN_SRCS =				\
 	main/options.c			\
 	main/output-etags.c		\
 	main/output-ctags.c		\
+	main/output-json.c		\
 	main/output-xref.c		\
 	main/parse.c			\
 	main/pcoproc.c			\
@@ -184,10 +185,6 @@ XML_SRCS = \
 	 parsers/xslt.c			\
 	 \
 	 $(NULL)
-
-JANSSON_HEADS =
-JANSSON_SRCS = \
-	main/output-json.c
 
 DEBUG_HEADS = main/debug.h
 DEBUG_SRCS = main/debug.c


### PR DESCRIPTION
I provide two commits. One is for building ctags without the library. Another is for testing ctags without the library.

If acceptable,  please merge my commits with "squashing" into your two commits.
