### PR TITLE
Render fields more unified way

### DIFF
--- a/main/field.c
+++ b/main/field.c
@@ -56,13 +56,28 @@ static const char *renderFieldExtra (const tagEntryInfo *const tag, const char *
 static const char *renderFieldXpath (const tagEntryInfo *const tag, const char *value, vString* b);
 static const char *renderFieldScopeKindName(const tagEntryInfo *const tag, const char *value, vString* b);
 
-#define DEFINE_FIELD_SPEC(L, N, V, H, F)	\
+static boolean     isLanguageFieldAvailable  (const tagEntryInfo *const tag);
+static boolean     isTyperefFieldAvailable   (const tagEntryInfo *const tag);
+static boolean     isFileFieldAvailable      (const tagEntryInfo *const tag);
+static boolean     isInheritsFieldAvailable  (const tagEntryInfo *const tag);
+static boolean     isAccessFieldAvailable    (const tagEntryInfo *const tag);
+static boolean     isImplementationFieldAvailable (const tagEntryInfo *const tag);
+static boolean     isSignatureFieldAvailable (const tagEntryInfo *const tag);
+static boolean     isRoleFieldAvailable      (const tagEntryInfo *const tag);
+static boolean     isExtraFieldAvailable     (const tagEntryInfo *const tag);
+static boolean     isXpathFieldAvailable     (const tagEntryInfo *const tag);
+
+
+#define DEFINE_FIELD_SPEC(L, N, V, H, F)		\
+	DEFINE_FIELD_SPEC_FULL (L, N, V, H, F, NULL)
+#define DEFINE_FIELD_SPEC_FULL(L, N, V, H, F, A)\
 	{					\
 		.letter        = L,		\
 		.name          = N,		\
 		.description   = H,		\
 		.enabled       = V,		\
 		.renderEscaped = F,		\
+		.isValueAvailable = A,		\
 	}
 
 #define WITH_DEFUALT_VALUE(str) ((str)?(str):"-")
@@ -86,48 +101,48 @@ static fieldSpec fieldSpecsExuberant [] = {
 			   renderFieldCompactInputLine),
 
 	/* EXTENSION FIELDS */
-	DEFINE_FIELD_SPEC ('a', "access",         FALSE,
+	DEFINE_FIELD_SPEC_FULL ('a', "access",         FALSE,
 		      "Access (or export) of class members",
-		      renderFieldAccess),
-	DEFINE_FIELD_SPEC ('f', "file",           TRUE,
+		      renderFieldAccess, isAccessFieldAvailable),
+	DEFINE_FIELD_SPEC_FULL ('f', "file",           TRUE,
 		      "File-restricted scoping",
-		      renderFieldFile),
-	DEFINE_FIELD_SPEC ('i', "inherits",       FALSE,
+		      renderFieldFile, isFileFieldAvailable),
+	DEFINE_FIELD_SPEC_FULL ('i', "inherits",       FALSE,
 		      "Inheritance information",
-		      renderFieldInherits),
+		      renderFieldInherits, isInheritsFieldAvailable),
 	DEFINE_FIELD_SPEC ('K', NULL,             FALSE,
 		      "Kind of tag as full name",
 		      renderFieldKindName),
 	DEFINE_FIELD_SPEC ('k', NULL,             TRUE,
 			   "Kind of tag as a single letter",
 			   renderFieldKindLetter),
-	DEFINE_FIELD_SPEC ('l', "language",       FALSE,
+	DEFINE_FIELD_SPEC_FULL ('l', "language",       FALSE,
 			   "Language of input file containing tag",
-			   renderFieldLanguage),
-	DEFINE_FIELD_SPEC ('m', "implementation", FALSE,
+			   renderFieldLanguage, isLanguageFieldAvailable),
+	DEFINE_FIELD_SPEC_FULL ('m', "implementation", FALSE,
 			   "Implementation information",
-			   renderFieldImplementation),
+			   renderFieldImplementation, isImplementationFieldAvailable),
 	DEFINE_FIELD_SPEC ('n', "line",           FALSE,
 			   "Line number of tag definition",
 			   renderFieldLineNumber),
-	DEFINE_FIELD_SPEC ('S', "signature",	     FALSE,
+	DEFINE_FIELD_SPEC_FULL ('S', "signature",	     FALSE,
 			   "Signature of routine (e.g. prototype or parameter list)",
-			   renderFieldSignature),
+			   renderFieldSignature, isSignatureFieldAvailable),
 	DEFINE_FIELD_SPEC ('s', NULL,             TRUE,
 			   "Scope of tag definition (`p' can be used for printing its kind)",
 			   renderFieldScope),
-	DEFINE_FIELD_SPEC ('t', "typeref",        TRUE,
+	DEFINE_FIELD_SPEC_FULL ('t', "typeref",        TRUE,
 			   "Type and name of a variable or typedef",
-			   renderFieldTyperef),
+			   renderFieldTyperef, isTyperefFieldAvailable),
 	DEFINE_FIELD_SPEC ('z', "kind",           FALSE,
 			   "Include the \"kind:\" key in kind field (use k or K)",
 			   NULL),
 };
 
 static fieldSpec fieldSpecsUniversal [] = {
-	DEFINE_FIELD_SPEC ('r', "role",    FALSE,
+	DEFINE_FIELD_SPEC_FULL ('r', "role",    FALSE,
 			   "Role",
-			   renderFieldRole),
+			   renderFieldRole, isRoleFieldAvailable),
 	DEFINE_FIELD_SPEC ('R',  NULL,     FALSE,
 			   "Marker (R or D) representing whether tag is definition or reference",
 			   renderFieldRefMarker),
@@ -136,12 +151,12 @@ static fieldSpec fieldSpecsUniversal [] = {
 			   /* Following renderer is for handling --_xformat=%{scope};
 			      and is not for tags output. */
 			   renderFieldScope),
-	DEFINE_FIELD_SPEC ('E', "extra",   FALSE,
+	DEFINE_FIELD_SPEC_FULL ('E', "extra",   FALSE,
 			   "Extra tag type information",
-			   renderFieldExtra),
-	DEFINE_FIELD_SPEC ('x', "xpath",   FALSE,
+			   renderFieldExtra, isExtraFieldAvailable),
+	DEFINE_FIELD_SPEC_FULL ('x', "xpath",   FALSE,
 			   "xpath for the tag",
-			   renderFieldXpath),
+			   renderFieldXpath, isXpathFieldAvailable),
 	DEFINE_FIELD_SPEC ('p', "scopeKind", TRUE,
 			   "Kind of scope as full name",
 			   renderFieldScopeKindName),
@@ -312,6 +327,14 @@ extern const char* getFieldName(fieldType type)
 		return fdesc->nameWithPrefix;
 	else
 		return fdesc->spec->name;
+}
+
+extern boolean doesFieldHaveValue (fieldType type, const struct sTagEntryInfo *tag)
+{
+	if (getFieldDesc(type)->spec->isValueAvailable)
+		return getFieldDesc(type)->spec->isValueAvailable(tag);
+	else
+		return TRUE;
 }
 
 #define PR_FIELD_WIDTH_LETTER     7
@@ -694,6 +717,68 @@ static const char *renderFieldScopeKindName(const tagEntryInfo *const tag,
 
 	getTagScopeInformation ((tagEntryInfo *const)tag, &kind, NULL);
 	return kind? renderAsIs (b, kind): NULL;
+}
+
+static boolean     isLanguageFieldAvailable (const tagEntryInfo *const tag)
+{
+	return (tag->language != NULL)? TRUE: FALSE;
+}
+
+static boolean     isTyperefFieldAvailable  (const tagEntryInfo *const tag)
+{
+	return (tag->extensionFields.typeRef [0] != NULL
+		&& tag->extensionFields.typeRef [1] != NULL)? TRUE: FALSE;
+}
+
+static boolean     isFileFieldAvailable  (const tagEntryInfo *const tag)
+{
+	return tag->isFileScope? TRUE: FALSE;
+}
+
+static boolean     isInheritsFieldAvailable (const tagEntryInfo *const tag)
+{
+	return (tag->extensionFields.inheritance != NULL)? TRUE: FALSE;
+}
+
+static boolean     isAccessFieldAvailable   (const tagEntryInfo *const tag)
+{
+	return (tag->extensionFields.access != NULL)? TRUE: FALSE;
+}
+
+static boolean     isImplementationFieldAvailable (const tagEntryInfo *const tag)
+{
+	return (tag->extensionFields.implementation != NULL)? TRUE: FALSE;
+}
+
+static boolean     isSignatureFieldAvailable (const tagEntryInfo *const tag)
+{
+	return (tag->extensionFields.signature != NULL)? TRUE: FALSE;
+}
+
+static boolean     isRoleFieldAvailable      (const tagEntryInfo *const tag)
+{
+	return (tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION)? TRUE: FALSE;
+}
+
+static boolean     isExtraFieldAvailable     (const tagEntryInfo *const tag)
+{
+	int i;
+	for (i = 0; i < sizeof (tag->extra); i++)
+	{
+		if (tag->extra [i])
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+static boolean     isXpathFieldAvailable      (const tagEntryInfo *const tag)
+{
+#ifdef HAVE_LIBXML
+	return (tag->extensionFields.xpath != NULL)? TRUE: FALSE;
+#else
+	return FALSE;
+#endif
 }
 
 extern boolean isFieldEnabled (fieldType type)

--- a/main/field.h
+++ b/main/field.h
@@ -56,6 +56,7 @@ struct sTagEntryInfo;
 typedef const char* (* renderEscaped) (const struct sTagEntryInfo *const tag,
 				       const char *value,
 				       vString * buffer);
+typedef boolean (* isValueAvailable) (const struct sTagEntryInfo *const tag);
 
 #define FIELD_LETTER_NO_USE '\0'
 typedef struct sFieldSpec {
@@ -67,6 +68,7 @@ typedef struct sFieldSpec {
 	const char* description;
 	boolean enabled;
 	renderEscaped renderEscaped;
+	isValueAvailable isValueAvailable;
 
 	unsigned int ftype;	/* Given from the main part */
 } fieldSpec;
@@ -84,6 +86,7 @@ extern void printFields (void);
 
 extern boolean isFieldRenderable (fieldType type);
 
+extern boolean doesFieldHaveValue (fieldType type, const struct sTagEntryInfo *tag);
 extern const char* renderFieldEscaped (fieldType type, const struct sTagEntryInfo *tag, int index);
 
 extern void initFieldDescs (void);

--- a/main/output-ctags.c
+++ b/main/output-ctags.c
@@ -131,6 +131,9 @@ static int addExtensionFields (MIO *mio, const tagEntryInfo *const tag)
 	{
 		const char* k = NULL, *v = NULL;
 
+		/* The value rendered in following calls are
+		   cached in tag. So even if FIELD_SCOPE is disabled,
+		   following calls are needed for automatic FQN generating. */
 		k = escapeFieldValue (tag, FIELD_SCOPE_KIND_LONG);
 		v = escapeFieldValue (tag, FIELD_SCOPE);
 

--- a/main/output-ctags.c
+++ b/main/output-ctags.c
@@ -103,12 +103,12 @@ static int addExtensionFields (MIO *mio, const tagEntryInfo *const tag)
 		length += mio_printf (mio, kindFmt, sep, kindKey, str);
 	}
 
-	if (isFieldEnabled (FIELD_LINE_NUMBER))
+	if (isFieldEnabled (FIELD_LINE_NUMBER) &&  doesFieldHaveValue (FIELD_LINE_NUMBER, tag))
 		length += mio_printf (mio, "%s\t%s:%ld", sep,
 				   getFieldName (FIELD_LINE_NUMBER),
 				   tag->lineNumber);
 
-	if (isFieldEnabled (FIELD_LANGUAGE)  &&  tag->language != NULL)
+	if (isFieldEnabled (FIELD_LANGUAGE)  &&  doesFieldHaveValue (FIELD_LANGUAGE, tag))
 		length += mio_printf (mio, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_LANGUAGE),
 				   escapeName (tag, FIELD_LANGUAGE));
@@ -124,65 +124,49 @@ static int addExtensionFields (MIO *mio, const tagEntryInfo *const tag)
 			length += mio_printf (mio, scopeFmt, sep, scopeKey, k, v);
 	}
 
-	if (isFieldEnabled (FIELD_TYPE_REF) &&
-	    tag->extensionFields.typeRef [0] != NULL  &&
-	    tag->extensionFields.typeRef [1] != NULL)
+	if (isFieldEnabled (FIELD_TYPE_REF) && doesFieldHaveValue (FIELD_TYPE_REF, tag))
 		length += mio_printf (mio, "%s\t%s:%s:%s", sep,
 				      getFieldName (FIELD_TYPE_REF),
 				      tag->extensionFields.typeRef [0],
 				      escapeName (tag, FIELD_TYPE_REF));
 
-	if (isFieldEnabled (FIELD_FILE_SCOPE) &&  tag->isFileScope)
+	if (isFieldEnabled (FIELD_FILE_SCOPE) &&  doesFieldHaveValue (FIELD_FILE_SCOPE, tag))
 		length += mio_printf (mio, "%s\t%s:", sep,
 				      getFieldName (FIELD_FILE_SCOPE));
 
-	if (isFieldEnabled (FIELD_INHERITANCE) &&
-			tag->extensionFields.inheritance != NULL)
+	if (isFieldEnabled (FIELD_INHERITANCE) && doesFieldHaveValue (FIELD_INHERITANCE, tag))
 		length += mio_printf (mio, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_INHERITANCE),
 				   escapeName (tag, FIELD_INHERITANCE));
 
-	if (isFieldEnabled (FIELD_ACCESS) &&  tag->extensionFields.access != NULL)
+	if (isFieldEnabled (FIELD_ACCESS) && doesFieldHaveValue (FIELD_ACCESS, tag))
 		length += mio_printf (mio, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_ACCESS),
 				   escapeName (tag, FIELD_ACCESS));
 
-	if (isFieldEnabled (FIELD_IMPLEMENTATION) &&
-			tag->extensionFields.implementation != NULL)
+	if (isFieldEnabled (FIELD_IMPLEMENTATION) && doesFieldHaveValue (FIELD_IMPLEMENTATION, tag))
 		length += mio_printf (mio, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_IMPLEMENTATION),
 				   escapeName (tag, FIELD_IMPLEMENTATION));
 
-	if (isFieldEnabled (FIELD_SIGNATURE) &&
-			tag->extensionFields.signature != NULL)
+	if (isFieldEnabled (FIELD_SIGNATURE) && doesFieldHaveValue (FIELD_SIGNATURE, tag))
 		length += mio_printf (mio, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_SIGNATURE),
 				   escapeName (tag, FIELD_SIGNATURE));
-	if (isFieldEnabled (FIELD_ROLE) && tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION)
+	if (isFieldEnabled (FIELD_ROLE) && doesFieldHaveValue (FIELD_ROLE, tag))
 		length += mio_printf (mio, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_ROLE),
 				   escapeName (tag, FIELD_ROLE));
 
-	if (isFieldEnabled (FIELD_EXTRA))
-	{
-		const char *value = escapeName (tag, FIELD_EXTRA);
-		if (value)
-			length += mio_printf (mio, "%s\t%s:%s", sep,
-					   getFieldName (FIELD_EXTRA),
-					   escapeName (tag, FIELD_EXTRA));
-	}
+	if (isFieldEnabled (FIELD_EXTRA) && doesFieldHaveValue (FIELD_EXTRA, tag))
+		length += mio_printf (mio, "%s\t%s:%s", sep,
+				      getFieldName (FIELD_EXTRA),
+				      escapeName (tag, FIELD_EXTRA));
 
-#ifdef HAVE_LIBXML
-	if (isFieldEnabled(FIELD_XPATH))
-	{
-		const char *value = escapeName (tag, FIELD_XPATH);
-		if (value)
-			length += mio_printf (mio, "%s\t%s:%s", sep,
-					      getFieldName (FIELD_XPATH),
-					      escapeName (tag, FIELD_XPATH));
-
-	}
-#endif
+	if (isFieldEnabled(FIELD_XPATH) && doesFieldHaveValue (FIELD_XPATH, tag))
+		length += mio_printf (mio, "%s\t%s:%s", sep,
+				      getFieldName (FIELD_XPATH),
+				      escapeName (tag, FIELD_XPATH));
 
 	return length;
 #undef sep

--- a/main/output-ctags.c
+++ b/main/output-ctags.c
@@ -187,9 +187,10 @@ extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data
 		length += writePatternEntry (mio, tag);
 
 	if (includeExtensionFlags ())
+	{
 		length += addExtensionFields (mio, tag);
-
-	length += addParserFields (mio, tag);
+		length += addParserFields (mio, tag);
+	}
 
 	length += mio_printf (mio, "\n");
 

--- a/main/output-ctags.c
+++ b/main/output-ctags.c
@@ -19,7 +19,7 @@
 #define includeExtensionFlags()         (Option.tagFileFormat > 1)
 
 
-static const char* escapeName (const tagEntryInfo * tag, fieldType ftype)
+static const char* escapeFieldValue (const tagEntryInfo * tag, fieldType ftype)
 {
 	return renderFieldEscaped (ftype, tag, NO_PARSER_FIELD);
 }
@@ -31,7 +31,7 @@ static int renderExtensionFieldMaybe (int xftype, const tagEntryInfo *const tag,
 		int len;
 		len = mio_printf (mio, "%s\t%s:%s", sep,
 				  getFieldName (xftype),
-				  escapeName (tag, xftype));
+				  escapeFieldValue (tag, xftype));
 		sep[0] = '\0';
 		return len;
 	}
@@ -61,7 +61,7 @@ static int addParserFields (MIO * mio, const tagEntryInfo *const tag)
 static int writeLineNumberEntry (MIO * mio, const tagEntryInfo *const tag)
 {
 	if (Option.lineDirectives)
-		return mio_printf (mio, "%s", escapeName (tag, FIELD_LINE_NUMBER));
+		return mio_printf (mio, "%s", escapeFieldValue (tag, FIELD_LINE_NUMBER));
 	else
 		return mio_printf (mio, "%lu", tag->lineNumber);
 }
@@ -131,8 +131,8 @@ static int addExtensionFields (MIO *mio, const tagEntryInfo *const tag)
 	{
 		const char* k = NULL, *v = NULL;
 
-		k = escapeName (tag, FIELD_SCOPE_KIND_LONG);
-		v = escapeName (tag, FIELD_SCOPE);
+		k = escapeFieldValue (tag, FIELD_SCOPE_KIND_LONG);
+		v = escapeFieldValue (tag, FIELD_SCOPE);
 
 		if (isFieldEnabled (FIELD_SCOPE) && k && v)
 		{
@@ -146,7 +146,7 @@ static int addExtensionFields (MIO *mio, const tagEntryInfo *const tag)
 		length += mio_printf (mio, "%s\t%s:%s:%s", sep,
 				      getFieldName (FIELD_TYPE_REF),
 				      tag->extensionFields.typeRef [0],
-				      escapeName (tag, FIELD_TYPE_REF));
+				      escapeFieldValue (tag, FIELD_TYPE_REF));
 		sep [0] = '\0';
 	}
 
@@ -176,8 +176,8 @@ static int writePatternEntry (MIO *mio, const tagEntryInfo *const tag)
 extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)
 {
 	int length = mio_printf (mio, "%s\t%s\t",
-			      escapeName (tag, FIELD_NAME),
-			      escapeName (tag, FIELD_INPUT_FILE));
+			      escapeFieldValue (tag, FIELD_NAME),
+			      escapeFieldValue (tag, FIELD_INPUT_FILE));
 
 	if (tag->lineNumberEntry)
 		length += writeLineNumberEntry (mio, tag);

--- a/main/output-ctags.c
+++ b/main/output-ctags.c
@@ -145,13 +145,13 @@ static int addExtensionFields (MIO *mio, const tagEntryInfo *const tag)
 	if (isFieldEnabled (FIELD_ACCESS) &&  tag->extensionFields.access != NULL)
 		length += mio_printf (mio, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_ACCESS),
-				   tag->extensionFields.access);
+				   escapeName (tag, FIELD_ACCESS));
 
 	if (isFieldEnabled (FIELD_IMPLEMENTATION) &&
 			tag->extensionFields.implementation != NULL)
 		length += mio_printf (mio, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_IMPLEMENTATION),
-				   tag->extensionFields.implementation);
+				   escapeName (tag, FIELD_IMPLEMENTATION));
 
 	if (isFieldEnabled (FIELD_SIGNATURE) &&
 			tag->extensionFields.signature != NULL)

--- a/main/output-json.c
+++ b/main/output-json.c
@@ -21,7 +21,7 @@
 
 #define includeExtensionFlags()         (Option.tagFileFormat > 1)
 
-static json_t* escapeName (const tagEntryInfo * tag, fieldType ftype)
+static json_t* escapeFieldValue (const tagEntryInfo * tag, fieldType ftype)
 {
 	const char *str = renderFieldEscaped (ftype, tag, NO_PARSER_FIELD);
 	if (str)
@@ -64,40 +64,40 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 		json_object_set_new (response, getFieldName (FIELD_LINE_NUMBER), json_integer (tag->lineNumber));
 
 	if (isFieldEnabled (FIELD_LANGUAGE)  &&  doesFieldHaveValue (FIELD_LANGUAGE))
-		json_object_set_new (response, getFieldName (FIELD_LANGUAGE), escapeName (tag, FIELD_LANGUAGE));
+		json_object_set_new (response, getFieldName (FIELD_LANGUAGE), escapeFieldValue (tag, FIELD_LANGUAGE));
 
 	if (isFieldEnabled (FIELD_SCOPE) || making_fq_tag)
 	{
 		if (isFieldEnabled (FIELD_SCOPE))
-			json_object_set_new (response, getFieldName (FIELD_SCOPE_KEY), escapeName (tag, FIELD_SCOPE_KIND_LONG));
+			json_object_set_new (response, getFieldName (FIELD_SCOPE_KEY), escapeFieldValue (tag, FIELD_SCOPE_KIND_LONG));
 	}
 
 	if (isFieldEnabled (FIELD_TYPE_REF) && doesFieldHaveValue (FIELD_TYPE_REF, tag))
-		json_object_set_new (response, getFieldName (FIELD_TYPE_REF), escapeName (tag, FIELD_TYPE_REF));
+		json_object_set_new (response, getFieldName (FIELD_TYPE_REF), escapeFieldValue (tag, FIELD_TYPE_REF));
 
 	if (isFieldEnabled (FIELD_FILE_SCOPE) &&  doesFieldHaveValue (FIELD_FILE_SCOPE, tag))
 		json_object_set_new (response, getFieldName (FIELD_FILE_SCOPE), json_boolean(1));
 
 	if (isFieldEnabled (FIELD_INHERITANCE) && doesFieldHaveValue (FIELD_INHERITANCE))
-		json_object_set_new (response, getFieldName (FIELD_INHERITANCE), escapeName (tag, FIELD_INHERITANCE));
+		json_object_set_new (response, getFieldName (FIELD_INHERITANCE), escapeFieldValue (tag, FIELD_INHERITANCE));
 
 	if (isFieldEnabled (FIELD_ACCESS) && doesFieldHaveValue (FIELD_ACCESS))
-		json_object_set_new (response, getFieldName (FIELD_ACCESS), escapeName (tag, FIELD_ACCESS));
+		json_object_set_new (response, getFieldName (FIELD_ACCESS), escapeFieldValue (tag, FIELD_ACCESS));
 
 	if (isFieldEnabled (FIELD_IMPLEMENTATION) && doesFieldHaveValue (FIELD_IMPLEMENTATION))
-		json_object_set_new (response, getFieldName (FIELD_IMPLEMENTATION), escapeName (tag, FIELD_IMPLEMENTATION));
+		json_object_set_new (response, getFieldName (FIELD_IMPLEMENTATION), escapeFieldValue (tag, FIELD_IMPLEMENTATION));
 
 	if (isFieldEnabled (FIELD_SIGNATURE) && doesFieldHaveValue (tag, FIELD_SIGNATURE))
-		json_object_set_new (response, getFieldName (FIELD_SIGNATURE), escapeName (tag, FIELD_SIGNATURE));
+		json_object_set_new (response, getFieldName (FIELD_SIGNATURE), escapeFieldValue (tag, FIELD_SIGNATURE));
 
 	if (isFieldEnabled (FIELD_ROLE) && doesFieldHaveValue (tag, FIELD_ROLE))
-		json_object_set_new (response, getFieldName (FIELD_ROLE), escapeName (tag, FIELD_ROLE));
+		json_object_set_new (response, getFieldName (FIELD_ROLE), escapeFieldValue (tag, FIELD_ROLE));
 
 	if (isFieldEnabled (FIELD_EXTRA) && doesFieldHaveValue (tag, FIELD_EXTRA))
-		json_object_set_new (response, getFieldName (FIELD_EXTRA), escapeName (tag, FIELD_EXTRA));
+		json_object_set_new (response, getFieldName (FIELD_EXTRA), escapeFieldValue (tag, FIELD_EXTRA));
 
 	if (isFieldEnabled(FIELD_XPATH) && doesFieldHaveValue (tag, FIELD_XPATH))
-		json_object_set_new (response, getFieldName (FIELD_XPATH), escapeName (tag, FIELD_XPATH));
+		json_object_set_new (response, getFieldName (FIELD_XPATH), escapeFieldValue (tag, FIELD_XPATH));
 }
 
 extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)

--- a/main/output-json.c
+++ b/main/output-json.c
@@ -30,6 +30,27 @@ static json_t* escapeFieldValue (const tagEntryInfo * tag, fieldType ftype)
 		return NULL;
 }
 
+static void renderExtensionFieldMaybe (int xftype, const tagEntryInfo *const tag, json_t *response)
+{
+	if (isFieldEnabled (xftype) && doesFieldHaveValue (xftype, tag))
+	{
+		switch (xftype)
+		{
+		case FIELD_LINE_NUMBER:
+			json_object_set_new (response, getFieldName (xftype),
+					     json_integer (tag->lineNumber));
+			break;
+		case FIELD_FILE_SCOPE:
+			json_object_set_new (response, getFieldName (xftype),
+					     json_boolean(1));
+			break;
+		default:
+			json_object_set_new (response, getFieldName (xftype),
+					     escapeFieldValue (tag, xftype));
+		}
+	}
+}
+
 static void addParserFields (json_t *response, const tagEntryInfo *const tag)
 {
 	unsigned int i;
@@ -60,11 +81,8 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 		json_object_set_new (response, getFieldName (FIELD_KIND_KEY), json_string (str));
 	}
 
-	if (isFieldEnabled (FIELD_LINE_NUMBER) && doesFieldHaveValue (FIELD_LINE_NUMBER, tag))
-		json_object_set_new (response, getFieldName (FIELD_LINE_NUMBER), json_integer (tag->lineNumber));
-
-	if (isFieldEnabled (FIELD_LANGUAGE)  &&  doesFieldHaveValue (FIELD_LANGUAGE))
-		json_object_set_new (response, getFieldName (FIELD_LANGUAGE), escapeFieldValue (tag, FIELD_LANGUAGE));
+	renderExtensionFieldMaybe (FIELD_LINE_NUMBER, tag, response);
+	renderExtensionFieldMaybe (FIELD_LANGUAGE, tag, response);
 
 	if (isFieldEnabled (FIELD_SCOPE) || making_fq_tag)
 	{
@@ -72,32 +90,16 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 			json_object_set_new (response, getFieldName (FIELD_SCOPE_KEY), escapeFieldValue (tag, FIELD_SCOPE_KIND_LONG));
 	}
 
-	if (isFieldEnabled (FIELD_TYPE_REF) && doesFieldHaveValue (FIELD_TYPE_REF, tag))
-		json_object_set_new (response, getFieldName (FIELD_TYPE_REF), escapeFieldValue (tag, FIELD_TYPE_REF));
+	renderExtensionFieldMaybe (FIELD_TYPE_REF, tag, response);
+	renderExtensionFieldMaybe (FIELD_SCOPE, tag, response);
+	renderExtensionFieldMaybe (FIELD_INHERITANCE, tag, response);
+	renderExtensionFieldMaybe (FIELD_ACCESS, tag, response);
+	renderExtensionFieldMaybe (FIELD_IMPLEMENTATION, tag, response);
+	renderExtensionFieldMaybe (FIELD_SIGNATURE, tag, response);
+	renderExtensionFieldMaybe (FIELD_ROLE, tag, response);
+	renderExtensionFieldMaybe (FIELD_EXTRA, tag, response);
+	renderExtensionFieldMaybe (FIELD_XPATH, tag, response);
 
-	if (isFieldEnabled (FIELD_FILE_SCOPE) &&  doesFieldHaveValue (FIELD_FILE_SCOPE, tag))
-		json_object_set_new (response, getFieldName (FIELD_FILE_SCOPE), json_boolean(1));
-
-	if (isFieldEnabled (FIELD_INHERITANCE) && doesFieldHaveValue (FIELD_INHERITANCE))
-		json_object_set_new (response, getFieldName (FIELD_INHERITANCE), escapeFieldValue (tag, FIELD_INHERITANCE));
-
-	if (isFieldEnabled (FIELD_ACCESS) && doesFieldHaveValue (FIELD_ACCESS))
-		json_object_set_new (response, getFieldName (FIELD_ACCESS), escapeFieldValue (tag, FIELD_ACCESS));
-
-	if (isFieldEnabled (FIELD_IMPLEMENTATION) && doesFieldHaveValue (FIELD_IMPLEMENTATION))
-		json_object_set_new (response, getFieldName (FIELD_IMPLEMENTATION), escapeFieldValue (tag, FIELD_IMPLEMENTATION));
-
-	if (isFieldEnabled (FIELD_SIGNATURE) && doesFieldHaveValue (tag, FIELD_SIGNATURE))
-		json_object_set_new (response, getFieldName (FIELD_SIGNATURE), escapeFieldValue (tag, FIELD_SIGNATURE));
-
-	if (isFieldEnabled (FIELD_ROLE) && doesFieldHaveValue (tag, FIELD_ROLE))
-		json_object_set_new (response, getFieldName (FIELD_ROLE), escapeFieldValue (tag, FIELD_ROLE));
-
-	if (isFieldEnabled (FIELD_EXTRA) && doesFieldHaveValue (tag, FIELD_EXTRA))
-		json_object_set_new (response, getFieldName (FIELD_EXTRA), escapeFieldValue (tag, FIELD_EXTRA));
-
-	if (isFieldEnabled(FIELD_XPATH) && doesFieldHaveValue (tag, FIELD_XPATH))
-		json_object_set_new (response, getFieldName (FIELD_XPATH), escapeFieldValue (tag, FIELD_XPATH));
 }
 
 extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)

--- a/main/output-json.c
+++ b/main/output-json.c
@@ -83,8 +83,12 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 
 	if (isFieldEnabled (FIELD_SCOPE) || making_fq_tag)
 	{
+		json_t *k = escapeFieldValue (tag, FIELD_SCOPE_KIND_LONG);
+
+		/* The value must be generated even if FIELD_SCOPE is disabled for
+		   generating FQN. */
 		if (isFieldEnabled (FIELD_SCOPE))
-			json_object_set_new (response, getFieldName (FIELD_SCOPE_KEY), escapeFieldValue (tag, FIELD_SCOPE_KIND_LONG));
+			json_object_set_new (response, getFieldName (FIELD_SCOPE_KEY), k);
 	}
 
 	int field_keys [] = {

--- a/main/output-json.c
+++ b/main/output-json.c
@@ -116,9 +116,10 @@ extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data 
 	);
 
 	if (includeExtensionFlags ())
+	{
 		addExtensionFields (response, tag);
-
-	addParserFields (response, tag);
+		addParserFields (response, tag);
+	}
 
 	char *buf = json_dumps (response, JSON_SORT_KEYS);
 	int length = mio_printf (mio, "%s\n", buf);

--- a/main/output-json.c
+++ b/main/output-json.c
@@ -81,25 +81,29 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 		json_object_set_new (response, getFieldName (FIELD_KIND_KEY), json_string (str));
 	}
 
-	renderExtensionFieldMaybe (FIELD_LINE_NUMBER, tag, response);
-	renderExtensionFieldMaybe (FIELD_LANGUAGE, tag, response);
-
 	if (isFieldEnabled (FIELD_SCOPE) || making_fq_tag)
 	{
 		if (isFieldEnabled (FIELD_SCOPE))
 			json_object_set_new (response, getFieldName (FIELD_SCOPE_KEY), escapeFieldValue (tag, FIELD_SCOPE_KIND_LONG));
 	}
 
-	renderExtensionFieldMaybe (FIELD_TYPE_REF, tag, response);
-	renderExtensionFieldMaybe (FIELD_SCOPE, tag, response);
-	renderExtensionFieldMaybe (FIELD_INHERITANCE, tag, response);
-	renderExtensionFieldMaybe (FIELD_ACCESS, tag, response);
-	renderExtensionFieldMaybe (FIELD_IMPLEMENTATION, tag, response);
-	renderExtensionFieldMaybe (FIELD_SIGNATURE, tag, response);
-	renderExtensionFieldMaybe (FIELD_ROLE, tag, response);
-	renderExtensionFieldMaybe (FIELD_EXTRA, tag, response);
-	renderExtensionFieldMaybe (FIELD_XPATH, tag, response);
-
+	int field_keys [] = {
+		FIELD_ACCESS,
+		FIELD_INHERITANCE,
+		FIELD_LANGUAGE,
+		FIELD_IMPLEMENTATION,
+		FIELD_LINE_NUMBER,
+		FIELD_SIGNATURE,
+		FIELD_SCOPE,
+		FIELD_TYPE_REF,
+		FIELD_ROLE,
+		FIELD_EXTRA,
+		FIELD_XPATH,
+		FIELD_UNKNOWN,
+	};
+	int *k;
+	for (k = field_keys; *k != FIELD_UNKNOWN; k++)
+		renderExtensionFieldMaybe (*k, tag, response);
 }
 
 extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)

--- a/main/output-json.c
+++ b/main/output-json.c
@@ -60,10 +60,10 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 		json_object_set_new (response, getFieldName (FIELD_KIND_KEY), json_string (str));
 	}
 
-	if (isFieldEnabled (FIELD_LINE_NUMBER))
+	if (isFieldEnabled (FIELD_LINE_NUMBER) && doesFieldHaveValue (FIELD_LINE_NUMBER, tag))
 		json_object_set_new (response, getFieldName (FIELD_LINE_NUMBER), json_integer (tag->lineNumber));
 
-	if (isFieldEnabled (FIELD_LANGUAGE)  &&  tag->language != NULL)
+	if (isFieldEnabled (FIELD_LANGUAGE)  &&  doesFieldHaveValue (FIELD_LANGUAGE))
 		json_object_set_new (response, getFieldName (FIELD_LANGUAGE), escapeName (tag, FIELD_LANGUAGE));
 
 	if (isFieldEnabled (FIELD_SCOPE) || making_fq_tag)
@@ -72,47 +72,32 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 			json_object_set_new (response, getFieldName (FIELD_SCOPE_KEY), escapeName (tag, FIELD_SCOPE_KIND_LONG));
 	}
 
-	if (isFieldEnabled (FIELD_TYPE_REF) &&
-	    tag->extensionFields.typeRef [0] != NULL  &&
-	    tag->extensionFields.typeRef [1] != NULL)
+	if (isFieldEnabled (FIELD_TYPE_REF) && doesFieldHaveValue (FIELD_TYPE_REF, tag))
 		json_object_set_new (response, getFieldName (FIELD_TYPE_REF), escapeName (tag, FIELD_TYPE_REF));
 
-	if (isFieldEnabled (FIELD_FILE_SCOPE) &&  tag->isFileScope)
+	if (isFieldEnabled (FIELD_FILE_SCOPE) &&  doesFieldHaveValue (FIELD_FILE_SCOPE, tag))
 		json_object_set_new (response, getFieldName (FIELD_FILE_SCOPE), json_boolean(1));
 
-	if (isFieldEnabled (FIELD_INHERITANCE) &&
-			tag->extensionFields.inheritance != NULL)
+	if (isFieldEnabled (FIELD_INHERITANCE) && doesFieldHaveValue (FIELD_INHERITANCE))
 		json_object_set_new (response, getFieldName (FIELD_INHERITANCE), escapeName (tag, FIELD_INHERITANCE));
 
-	if (isFieldEnabled (FIELD_ACCESS) &&  tag->extensionFields.access != NULL)
-		json_object_set_new (response, getFieldName (FIELD_ACCESS), json_string (tag->extensionFields.access));
+	if (isFieldEnabled (FIELD_ACCESS) && doesFieldHaveValue (FIELD_ACCESS))
+		json_object_set_new (response, getFieldName (FIELD_ACCESS), escapeName (tag, FIELD_ACCESS));
 
-	if (isFieldEnabled (FIELD_IMPLEMENTATION) &&
-			tag->extensionFields.implementation != NULL)
-		json_object_set_new (response, getFieldName (FIELD_IMPLEMENTATION), json_string (tag->extensionFields.implementation));
+	if (isFieldEnabled (FIELD_IMPLEMENTATION) && doesFieldHaveValue (FIELD_IMPLEMENTATION))
+		json_object_set_new (response, getFieldName (FIELD_IMPLEMENTATION), escapeName (tag, FIELD_IMPLEMENTATION));
 
-	if (isFieldEnabled (FIELD_SIGNATURE) &&
-			tag->extensionFields.signature != NULL)
+	if (isFieldEnabled (FIELD_SIGNATURE) && doesFieldHaveValue (tag, FIELD_SIGNATURE))
 		json_object_set_new (response, getFieldName (FIELD_SIGNATURE), escapeName (tag, FIELD_SIGNATURE));
 
-	if (isFieldEnabled (FIELD_ROLE) && tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION)
+	if (isFieldEnabled (FIELD_ROLE) && doesFieldHaveValue (tag, FIELD_ROLE))
 		json_object_set_new (response, getFieldName (FIELD_ROLE), escapeName (tag, FIELD_ROLE));
 
-	if (isFieldEnabled (FIELD_EXTRA))
-	{
-		json_t *value = escapeName (tag, FIELD_EXTRA);
-		if (value)
-			json_object_set_new (response, getFieldName (FIELD_EXTRA), value);
-	}
+	if (isFieldEnabled (FIELD_EXTRA) && doesFieldHaveValue (tag, FIELD_EXTRA))
+		json_object_set_new (response, getFieldName (FIELD_EXTRA), escapeName (tag, FIELD_EXTRA));
 
-#ifdef HAVE_LIBXML
-	if (isFieldEnabled(FIELD_XPATH))
-	{
-		json_t *value = escapeName (tag, FIELD_XPATH);
-		if (value)
-			json_object_set_new (response, getFieldName (FIELD_XPATH), value);
-	}
-#endif
+	if (isFieldEnabled(FIELD_XPATH) && doesFieldHaveValue (tag, FIELD_XPATH))
+		json_object_set_new (response, getFieldName (FIELD_XPATH), escapeName (tag, FIELD_XPATH));
 }
 
 extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)


### PR DESCRIPTION
Many structures of code were duplicated between output-ctags.c and output-json.c.
I refactored them. I tried to move common code between two files to field.c.

About scope and kind fields, we can do more. But the current version is much better than before.
